### PR TITLE
Use latest adapter version and update database name

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -7,7 +7,7 @@
     "max": 50
   },
   "rethinkdb": {
-    "db": "server",
+    "db": "feathers_chat",
     "servers": [
       {
         "host": "localhost",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "feathers-hooks": "^1.8.1",
     "feathers-hooks-common": "^3.0.0-pre.1",
     "feathers-rest": "^1.7.1",
-    "feathers-rethinkdb": "^0.3.7",
+    "feathers-rethinkdb": "^0.4.1",
     "feathers-socketio": "^1.5.2",
     "helmet": "^3.5.0",
     "rethinkdbdash": "^2.3.28",


### PR DESCRIPTION
This should fix the chat to work with RethinkDB.